### PR TITLE
Fix Error loading java.security file

### DIFF
--- a/prepare-jdk.cmd.sh
+++ b/prepare-jdk.cmd.sh
@@ -8,3 +8,4 @@ umask 0002
 mkdir -p /tmp/sub/jdk/lib/server/
 lz4 -d /jdk/lib/server/libjvm.so.lz4 /tmp/sub/jdk/lib/server/libjvm.so
 ln -s -t /tmp/sub/jdk/lib /jdk/lib/* 2>/dev/null
+ln -s -t /tmp/sub/jdk /jdk/conf 2>/dev/null


### PR DESCRIPTION
```
+ /jdk/bin/jar -x -f aws-lambda-java-runtime-interface-client-1.0.0.jar aws-lambda-runtime-interface-client.musl.so aws-lambda-runtime-interface-client.glibc.so Exception in thread "main" java.lang.InternalError: Error loading java.security file
	at java.base/java.security.Security.initialize(Security.java:105)
	at java.base/java.security.Security.lambda$static$0(Security.java:84)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:319)
	at java.base/java.security.Security.<clinit>(Security.java:83)
	at java.base/sun.security.util.SecurityProperties.getOverridableProperty(SecurityProperties.java:57)
	at java.base/sun.security.util.SecurityProperties.privilegedGetOverridable(SecurityProperties.java:48)
	at java.base/sun.security.util.SecurityProperties.includedInExceptions(SecurityProperties.java:72)
	at java.base/sun.security.util.SecurityProperties.<clinit>(SecurityProperties.java:36)
	at java.base/sun.security.util.FilePermCompat.<clinit>(FilePermCompat.java:43)
	at java.base/java.security.AccessControlContext.<init>(AccessControlContext.java:270)
	at java.base/java.security.AccessController.createWrapper(AccessController.java:649)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:461)
	at java.base/java.util.ResourceBundle$ResourceBundleProviderHelper.loadResourceBundle(ResourceBundle.java:3626)
	at java.base/java.util.ResourceBundle.loadBundle(ResourceBundle.java:1849)
	at java.base/java.util.ResourceBundle.findBundle(ResourceBundle.java:1780)
	at java.base/java.util.ResourceBundle.findBundle(ResourceBundle.java:1734)
	at java.base/java.util.ResourceBundle.getBundleImpl(ResourceBundle.java:1668)
	at java.base/java.util.ResourceBundle.getBundleImpl(ResourceBundle.java:1587)
	at java.base/java.util.ResourceBundle.getBundleImpl(ResourceBundle.java:1553)
	at java.base/java.util.ResourceBundle.getBundle(ResourceBundle.java:859)
	at jdk.jartool/sun.tools.jar.Main.<clinit>(Main.java:195)
```
Tested on Fedora 38 x86_64 which needs another patch.